### PR TITLE
feat: remove typedoc attribution in footer

### DIFF
--- a/typedoc.json
+++ b/typedoc.json
@@ -8,6 +8,7 @@
   "includeVersion": false,
   "router": "structure-dir",
   "customCss": "theme/style.css",
+  "hideGenerator": true,
   "navigation": {
     "includeCategories": true,
     "includeFolders": false


### PR DESCRIPTION
Removes the 'Generated using Typedoc' link in the site footer. We can add custom text in there if we want, maybe something for later!