### PR TITLE
chore: add markdown to highlightLanguages

### DIFF
--- a/typedoc.json
+++ b/typedoc.json
@@ -27,7 +27,8 @@
     "jsonc",
     "json5",
     "tsx",
-    "typescript"
+    "typescript",
+    "markdown"
   ],
   "ignoredHighlightLanguages": ["groq"]
 }


### PR DESCRIPTION
In attempting to get the core `sanity` monolith into the reference docs, I get the occasional item that breaks the build due to markdown highlighting. Haven't identified the exact reference, but no harm in adding it to the approved list. Note that adding it to the ignore list did not seem to work 🤷.