### PR TITLE
fix: always redirect to trailing slash URLs

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "trailingSlash": true
+}


### PR DESCRIPTION
### Description

Enables `vercel.trailingSlash` to prevent ending up on routes without a trailing slash, which breaks Typedoc's URL generation 🤷🏻 ✨ 😅 

### What to review

- The config is güd

### Testing

- Open the preview deployment and try to remove a trailing slash from a URL; it should redirect back to the trailing slash route
