### PR TITLE
feat: update sidebar height

### DIFF
--- a/theme/style.css
+++ b/theme/style.css
@@ -89,11 +89,23 @@ pre {
   border-radius: 8px;
   border: 1px solid light-dark(var(--gray200), var(--gray800));
   padding: 1.5rem;
+  box-shadow: 0 6px 12px rgba(0, 0, 0, 0.0675);
 }
 
 @media (min-width: 770px) {
+  /* Unset Typedoc theme max height */
+  .col-sidebar {
+    max-height: none;
+  }
   .col-content {
     padding: 3vw;
+  }
+}
+
+@media (min-width: 1200px) {
+  /* Unset Typedoc theme max height */
+  .site-menu {
+    max-height: none;
   }
 }
 


### PR DESCRIPTION
### Description

Removes the Typedoc default theme's max height on navigation sidebars to ensure sidebar content is visible.

<img width="1624" height="1056" alt="image" src="https://github.com/user-attachments/assets/85758ed3-67c5-4409-b7e1-66c23997c177" />

### What to review

- Is the new implementation appropriate?
- Does it solve the issue in [the filed ticket](https://linear.app/sanity/issue/DOC-1258/improve-reference-docs-nav-scrollability-affordance)?

### Testing

N/A
