### PR TITLE
feat: add GTM tracking script

### DIFF
--- a/typedoc.json
+++ b/typedoc.json
@@ -9,7 +9,7 @@
   "router": "structure-dir",
   "readme": "./README.typedoc.md",
   "customCss": "theme/style.css",
-  "customFooterHtml": "<a href=\"https://www.sanity.io?ref=reference-docs-site\">Sanity Content Operating System</a><!-- Fathom - beautiful, simple website analytics --> <script src=\"https://cdn.usefathom.com/script.js\" data-site=\"XRTTNUXT\" defer></script> <!-- / Fathom -->",
+  "customFooterHtml": "<a href=\"https://www.sanity.io?ref=reference-docs-site\">Sanity Content Operating System</a><!-- Fathom - beautiful, simple website analytics --> <script src=\"https://cdn.usefathom.com/script.js\" data-site=\"XRTTNUXT\" defer></script> <!-- / Fathom --><!-- Google Tag Manager --><script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0], j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-N3ZSHCP');</script><noscript><iframe src=\"https://www.googletagmanager.com/ns.html?id=GTM-N3ZSHCP\" height=\"0\" width=\"0\" style=\"display:none;visibility:hidden\"></iframe></noscript><!-- End Google Tag Manager -->",
   "hideGenerator": true,
   "navigation": {
     "includeCategories": true,


### PR DESCRIPTION
### Description

- Adds GTM tracking script
- Added to `customFooterHtml` as best compromise. Could alternatively add as customJs but this would be deferred, so this is best option.  
- Solves https://linear.app/sanity/issue/GRO-3920/add-google-tag-manager-to-reference-docs

### Testing

- Ensure GTM script loads correctly