### PR TITLE
feat: add llms.txt, sitemap.xml, and robots.txt

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "main": "index.js",
   "scripts": {
     "build:action": "cd .github/actions/typedoc-upload && npm run build",
-    "build:docs": "tsx src/build.ts && typedoc && cp 404-template.html docs/404.html",
+    "build:docs": "tsx src/build.ts && typedoc && tsx src/build-llms.ts && cp 404-template.html docs/404.html",
     "dev": "http-server docs -a localhost",
     "format": "prettier --write .",
     "prepare": "husky",

--- a/src/build-llms.ts
+++ b/src/build-llms.ts
@@ -1,0 +1,159 @@
+import fs from 'fs/promises'
+import path from 'path'
+
+const SITE_URL = 'https://reference.sanity.io'
+const INPUT_DIR = 'input-docs'
+const DOCS_DIR = 'docs'
+const LLMS_FILE = 'docs/llms.txt'
+const SITEMAP_FILE = 'docs/sitemap.xml'
+const ROBOTS_FILE = 'docs/robots.txt'
+
+type CommentPart = {kind: string; text: string}
+
+function joinParts(parts: unknown): string {
+  if (!Array.isArray(parts)) return ''
+  return (parts as CommentPart[]).map((p) => (typeof p?.text === 'string' ? p.text : '')).join('')
+}
+
+function truncate(text: string, max = 240): string {
+  if (text.length <= max) return text
+  return text.slice(0, max - 1).trimEnd() + '…'
+}
+
+function extractFirstProseParagraph(text: string): string | null {
+  if (!text) return null
+  let cleaned = text.replace(/<!--[\s\S]*?-->/g, '')
+  while (true) {
+    const m = cleaned.match(/^\s*<(p|div)\b[^>]*>[\s\S]*?<\/\1>\s*/i)
+    if (!m) break
+    cleaned = cleaned.slice(m[0].length)
+  }
+  for (const raw of cleaned.split(/\n\s*\n/)) {
+    let para = raw.trim()
+    if (!para) continue
+    if (para.startsWith('#')) continue
+    if (/^>\s*\[!/.test(para)) continue
+    if (para.startsWith('```') || para.startsWith('~~~')) continue
+    if (/^ {4}/.test(para)) continue
+    if (para.startsWith('<')) continue
+    const lines = para.split('\n')
+    const isBadgeOnly = lines.every((l) => {
+      const t = l.trim()
+      return !t || /^\[?!\[/.test(t)
+    })
+    if (isBadgeOnly) continue
+    if (para.startsWith('>')) {
+      para = para
+        .split('\n')
+        .map((l) => l.replace(/^\s*>\s?/, ''))
+        .join('\n')
+        .trim()
+      para = para.split(/\n\s*\n/)[0].trim()
+    }
+    return para.replace(/\s+/g, ' ').trim()
+  }
+  return null
+}
+
+function packageSlug(npmName: string): string {
+  return npmName.replace(/^@/, '_')
+}
+
+async function readDescription(jsonPath: string): Promise<string | null> {
+  let raw: string
+  try {
+    raw = await fs.readFile(jsonPath, 'utf-8')
+  } catch {
+    return null
+  }
+  let data: {comment?: {summary?: unknown}; readme?: unknown}
+  try {
+    data = JSON.parse(raw)
+  } catch {
+    return null
+  }
+  const summary = extractFirstProseParagraph(joinParts(data.comment?.summary))
+  if (summary) return truncate(summary)
+  const readme = extractFirstProseParagraph(joinParts(data.readme))
+  if (readme) return truncate(readme)
+  return null
+}
+
+async function readPackageName(jsonPath: string): Promise<string | null> {
+  try {
+    const raw = await fs.readFile(jsonPath, 'utf-8')
+    const data = JSON.parse(raw) as {name?: string}
+    return typeof data.name === 'string' ? data.name : null
+  } catch {
+    return null
+  }
+}
+
+const dirents = await fs.readdir(INPUT_DIR, {withFileTypes: true})
+const dirs = dirents.filter((d) => d.isDirectory()).map((d) => d.name)
+
+const packages: {name: string; description: string | null}[] = []
+for (const dir of dirs) {
+  const jsonPath = path.join(INPUT_DIR, dir, 'typedoc.json')
+  const name = await readPackageName(jsonPath)
+  if (!name) {
+    console.warn(`Skipping ${dir}: missing or unreadable typedoc.json`)
+    continue
+  }
+  const description = await readDescription(jsonPath)
+  packages.push({name, description})
+}
+
+packages.sort((a, b) => a.name.localeCompare(b.name))
+
+const lines: string[] = []
+lines.push('# Sanity API Reference')
+lines.push('')
+lines.push(
+  '> Unified TypeDoc-generated API reference for Sanity JavaScript libraries — clients, SDKs, visual editing, and adjacent packages.',
+)
+lines.push('')
+lines.push('## Packages')
+lines.push('')
+for (const pkg of packages) {
+  const url = `${SITE_URL}/${packageSlug(pkg.name)}/`
+  lines.push(
+    pkg.description ? `- [${pkg.name}](${url}): ${pkg.description}` : `- [${pkg.name}](${url})`,
+  )
+}
+lines.push('')
+
+await fs.writeFile(LLMS_FILE, lines.join('\n'), 'utf-8')
+console.log(`Wrote ${LLMS_FILE} with ${packages.length} packages`)
+
+async function collectIndexHtmlPaths(dir: string): Promise<string[]> {
+  const entries = await fs.readdir(dir, {withFileTypes: true, recursive: true})
+  return entries
+    .filter((e) => e.isFile() && e.name === 'index.html')
+    .map((e) => path.join(e.parentPath ?? dir, e.name))
+}
+
+function htmlPathToUrl(filePath: string): string {
+  const rel = path.relative(DOCS_DIR, filePath)
+  const dir = path.dirname(rel).split(path.sep).join('/')
+  const slug = dir === '.' ? '' : `${dir}/`
+  return `${SITE_URL}/${slug}`
+}
+
+const indexFiles = await collectIndexHtmlPaths(DOCS_DIR)
+const urls = indexFiles.map(htmlPathToUrl).sort()
+
+const sitemapLines: string[] = []
+sitemapLines.push('<?xml version="1.0" encoding="UTF-8"?>')
+sitemapLines.push('<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">')
+for (const url of urls) {
+  sitemapLines.push(`  <url><loc>${url}</loc></url>`)
+}
+sitemapLines.push('</urlset>')
+sitemapLines.push('')
+await fs.writeFile(SITEMAP_FILE, sitemapLines.join('\n'), 'utf-8')
+console.log(`Wrote ${SITEMAP_FILE} with ${urls.length} URLs`)
+
+const robots = ['User-agent: *', 'Allow: /', '', `Sitemap: ${SITE_URL}/sitemap.xml`, ''].join('\n')
+await fs.writeFile(ROBOTS_FILE, robots, 'utf-8')
+console.log(`Wrote ${ROBOTS_FILE}`)


### PR DESCRIPTION
## Summary

Adds a post-build step that emits three files at the site root to make the reference docs more discoverable to AI agents and crawlers:

- **`llms.txt`** — package index following the [llmstxt.org](https://llmstxt.org/) convention, with descriptions extracted from each package's TypeDoc readme.
- **`sitemap.xml`** — every TypeDoc-generated page (~2,084 URLs at last build), trailing-slash form to match `vercel.json`.
- **`robots.txt`** — allow-all with a `Sitemap:` pointer.

URL pattern was verified by decoding the live site's `assets/navigation.js`: `@sanity/x` → `/_sanity/x/`, unscoped packages → `/<name>/`.

## Implementation

A new `src/build-llms.ts` runs after `typedoc` in `build:docs`. It:

1. Reads each `input-docs/<dir>/typedoc.json` for the package `name` and pulls a description from `comment.summary` (falls back to the first prose paragraph of `readme`, skipping logo HTML wrappers, H1s, badges, code fences, and GitHub callouts).
2. Walks `docs/**/index.html` to enumerate canonical URLs for the sitemap.
3. Emits all three files into `docs/`.

Sample `llms.txt` output (full file in the build):

```
# Sanity API Reference

> Unified TypeDoc-generated API reference for Sanity JavaScript libraries — clients, SDKs, visual editing, and adjacent packages.

## Packages

- [@sanity/client](https://reference.sanity.io/_sanity/client/): JavaScript client for Sanity. Works in modern browsers, as well as runtimes like [Node.js], [Bun], [Deno], and [Edge Runtime]
- [@sanity/sdk-react](https://reference.sanity.io/_sanity/sdk-react/): React hooks for creating Sanity applications. Live by default, optimistic updates, multi-project support.
- [content-agent](https://reference.sanity.io/content-agent/): Vercel AI SDK provider for Sanity Content Agent API.
…
```

## Out of scope (filed as follow-up)

`llms-full.txt` (single-file dump of every symbol) and per-page markdown via content negotiation are tracked in [DOC-2118](https://linear.app/sanity/issue/DOC-2118/add-llms-fulltxt-and-per-page-markdown-to-referencesanityio).

## Test plan

Vercel preview: https://reference-api-typedoc-git-add-llms-txt-support.sanity.build

- [ ] [`/llms.txt`](https://reference-api-typedoc-git-add-llms-txt-support.sanity.build/llms.txt) returns 200 with `text/plain` and lists all 11 packages with descriptions
- [ ] [`/sitemap.xml`](https://reference-api-typedoc-git-add-llms-txt-support.sanity.build/sitemap.xml) returns 200 with `application/xml` and validates against the [sitemaps.org schema](https://www.sitemaps.org/protocol.html)
- [ ] [`/robots.txt`](https://reference-api-typedoc-git-add-llms-txt-support.sanity.build/robots.txt) returns 200 and points at the sitemap
- [ ] Spot-check a few sitemap URLs return 200 on the preview, e.g. [`/_sanity/client/`](https://reference-api-typedoc-git-add-llms-txt-support.sanity.build/_sanity/client/), [`/_sanity/sdk-react/`](https://reference-api-typedoc-git-add-llms-txt-support.sanity.build/_sanity/sdk-react/), [`/sanity/`](https://reference-api-typedoc-git-add-llms-txt-support.sanity.build/sanity/)
- [ ] Confirm `llms.txt` descriptions look reasonable for all 11 packages
- [ ] Post-merge: submit `https://reference.sanity.io/sitemap.xml` to Google Search Console and confirm it parses cleanly