### PR TITLE
feat: add llms.txt discovery + per-page markdown

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "http-server": "^14.1.1",
     "husky": "^9.1.7",
     "tsx": "^4.19.4",
-    "typedoc": "^0.28.3"
+    "typedoc": "^0.28.3",
+    "typedoc-plugin-markdown": "^4.11.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       typedoc:
         specifier: ^0.28.3
         version: 0.28.3(typescript@5.8.3)
+      typedoc-plugin-markdown:
+        specifier: ^4.11.0
+        version: 4.11.0(typedoc@0.28.3(typescript@5.8.3))
 
   .github/actions/typedoc-upload:
     dependencies:
@@ -1293,6 +1296,12 @@ packages:
     resolution: {integrity: sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==}
     engines: {node: '>=0.6.11 <=0.7.0 || >=0.7.3'}
 
+  typedoc-plugin-markdown@4.11.0:
+    resolution: {integrity: sha512-2iunh2ALyfyh204OF7h2u0kuQ84xB3jFZtFyUr01nThJkLvR8oGGSSDlyt2gyO4kXhvUxDcVbO0y43+qX+wFbw==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      typedoc: 0.28.x
+
   typedoc@0.28.3:
     resolution: {integrity: sha512-5svOCTfXvVSh6zbZKSQluZhR8yN2tKpTeHZxlmWpE6N5vc3R8k/jhg9nnD6n5tN9/ObuQTojkONrOxFdUFUG9w==}
     engines: {node: '>= 18', pnpm: '>= 10'}
@@ -2541,6 +2550,10 @@ snapshots:
       safe-buffer: 5.2.1
 
   tunnel@0.0.6: {}
+
+  typedoc-plugin-markdown@4.11.0(typedoc@0.28.3(typescript@5.8.3)):
+    dependencies:
+      typedoc: 0.28.3(typescript@5.8.3)
 
   typedoc@0.28.3(typescript@5.8.3):
     dependencies:

--- a/src/build-llms.ts
+++ b/src/build-llms.ts
@@ -123,10 +123,21 @@ for (const pkg of packages) {
   )
 }
 lines.push('')
+lines.push('## Per-package full reference')
+lines.push('')
+lines.push(
+  '> Same content as `llms-full.txt` below, but split per package so each file fits in a smaller context window. Pull only the package(s) you need.',
+)
+lines.push('')
+for (const pkg of packages) {
+  const fullUrl = `${SITE_URL}/${packageSlug(pkg.name)}/llms-full.txt`
+  lines.push(`- [${pkg.name}](${fullUrl})`)
+}
+lines.push('')
 lines.push('## Optional')
 lines.push('')
 lines.push(
-  `- [Full reference](${SITE_URL}/llms-full.txt): every public symbol's signature and description, concatenated for one-shot ingestion.`,
+  `- [Full reference](${SITE_URL}/llms-full.txt): every public symbol across all packages, concatenated. ~1.2M tokens — only useful for agents with a 1M+ context window. For everything else, use the per-package files above.`,
 )
 lines.push('')
 
@@ -181,25 +192,48 @@ function mdPathToUrl(filePath: string): string {
 
 const mdFiles = (await collectIndexMdPaths(DOCS_DIR)).sort()
 
-const fullLines: string[] = []
-fullLines.push('# Sanity API Reference (full)')
-fullLines.push('')
-fullLines.push(
-  `> Concatenation of every page on ${SITE_URL}/, in markdown form. For the package index, see ${SITE_URL}/llms.txt.`,
-)
-fullLines.push('')
-
-for (const file of mdFiles) {
-  const url = mdPathToUrl(file)
-  const body = (await fs.readFile(file, 'utf-8')).trim()
-  if (!body) continue
-  fullLines.push('---')
-  fullLines.push('')
-  fullLines.push(`Source: ${url}`)
-  fullLines.push('')
-  fullLines.push(body)
-  fullLines.push('')
+async function buildSections(files: string[]): Promise<string[]> {
+  const out: string[] = []
+  for (const file of files) {
+    const url = mdPathToUrl(file)
+    const body = (await fs.readFile(file, 'utf-8')).trim()
+    if (!body) continue
+    out.push('---', '', `Source: ${url}`, '', body, '')
+  }
+  return out
 }
 
+const fullLines: string[] = [
+  '# Sanity API Reference (full)',
+  '',
+  `> Concatenation of every page on ${SITE_URL}/, in markdown form. For the package index, see ${SITE_URL}/llms.txt.`,
+  '',
+  ...(await buildSections(mdFiles)),
+]
 await fs.writeFile(LLMS_FULL_FILE, fullLines.join('\n'), 'utf-8')
 console.log(`Wrote ${LLMS_FULL_FILE} with ${mdFiles.length} pages`)
+
+const filesByPackage = new Map<string, string[]>()
+for (const file of mdFiles) {
+  const rel = path.relative(DOCS_DIR, file).split(path.sep).join('/')
+  for (const pkg of packages) {
+    const slug = packageSlug(pkg.name)
+    if (rel === `${slug}/index.md` || rel.startsWith(`${slug}/`)) {
+      if (!filesByPackage.has(slug)) filesByPackage.set(slug, [])
+      filesByPackage.get(slug)!.push(file)
+      break
+    }
+  }
+}
+
+for (const pkg of packages) {
+  const slug = packageSlug(pkg.name)
+  const pkgFiles = filesByPackage.get(slug) ?? []
+  if (pkgFiles.length === 0) continue
+  const pkgLines: string[] = [`# ${pkg.name}`, '']
+  if (pkg.description) pkgLines.push(`> ${pkg.description}`, '')
+  pkgLines.push(...(await buildSections(pkgFiles)))
+  const outPath = path.join(DOCS_DIR, slug, 'llms-full.txt')
+  await fs.writeFile(outPath, pkgLines.join('\n'), 'utf-8')
+  console.log(`Wrote ${outPath} with ${pkgFiles.length} pages`)
+}

--- a/src/build-llms.ts
+++ b/src/build-llms.ts
@@ -5,6 +5,7 @@ const SITE_URL = 'https://reference.sanity.io'
 const INPUT_DIR = 'input-docs'
 const DOCS_DIR = 'docs'
 const LLMS_FILE = 'docs/llms.txt'
+const LLMS_FULL_FILE = 'docs/llms-full.txt'
 const SITEMAP_FILE = 'docs/sitemap.xml'
 const ROBOTS_FILE = 'docs/robots.txt'
 
@@ -122,6 +123,12 @@ for (const pkg of packages) {
   )
 }
 lines.push('')
+lines.push('## Optional')
+lines.push('')
+lines.push(
+  `- [Full reference](${SITE_URL}/llms-full.txt): every public symbol's signature and description, concatenated for one-shot ingestion.`,
+)
+lines.push('')
 
 await fs.writeFile(LLMS_FILE, lines.join('\n'), 'utf-8')
 console.log(`Wrote ${LLMS_FILE} with ${packages.length} packages`)
@@ -157,3 +164,42 @@ console.log(`Wrote ${SITEMAP_FILE} with ${urls.length} URLs`)
 const robots = ['User-agent: *', 'Allow: /', '', `Sitemap: ${SITE_URL}/sitemap.xml`, ''].join('\n')
 await fs.writeFile(ROBOTS_FILE, robots, 'utf-8')
 console.log(`Wrote ${ROBOTS_FILE}`)
+
+async function collectIndexMdPaths(dir: string): Promise<string[]> {
+  const entries = await fs.readdir(dir, {withFileTypes: true, recursive: true})
+  return entries
+    .filter((e) => e.isFile() && e.name === 'index.md')
+    .map((e) => path.join(e.parentPath ?? dir, e.name))
+}
+
+function mdPathToUrl(filePath: string): string {
+  const rel = path.relative(DOCS_DIR, filePath)
+  const dir = path.dirname(rel).split(path.sep).join('/')
+  const slug = dir === '.' ? '' : `${dir}/`
+  return `${SITE_URL}/${slug}`
+}
+
+const mdFiles = (await collectIndexMdPaths(DOCS_DIR)).sort()
+
+const fullLines: string[] = []
+fullLines.push('# Sanity API Reference (full)')
+fullLines.push('')
+fullLines.push(
+  `> Concatenation of every page on ${SITE_URL}/, in markdown form. For the package index, see ${SITE_URL}/llms.txt.`,
+)
+fullLines.push('')
+
+for (const file of mdFiles) {
+  const url = mdPathToUrl(file)
+  const body = (await fs.readFile(file, 'utf-8')).trim()
+  if (!body) continue
+  fullLines.push('---')
+  fullLines.push('')
+  fullLines.push(`Source: ${url}`)
+  fullLines.push('')
+  fullLines.push(body)
+  fullLines.push('')
+}
+
+await fs.writeFile(LLMS_FULL_FILE, fullLines.join('\n'), 'utf-8')
+console.log(`Wrote ${LLMS_FULL_FILE} with ${mdFiles.length} pages`)

--- a/src/build-llms.ts
+++ b/src/build-llms.ts
@@ -5,7 +5,6 @@ const SITE_URL = 'https://reference.sanity.io'
 const INPUT_DIR = 'input-docs'
 const DOCS_DIR = 'docs'
 const LLMS_FILE = 'docs/llms.txt'
-const LLMS_FULL_FILE = 'docs/llms-full.txt'
 const SITEMAP_FILE = 'docs/sitemap.xml'
 const ROBOTS_FILE = 'docs/robots.txt'
 
@@ -117,28 +116,11 @@ lines.push('')
 lines.push('## Packages')
 lines.push('')
 for (const pkg of packages) {
-  const url = `${SITE_URL}/${packageSlug(pkg.name)}/`
+  const url = `${SITE_URL}/${packageSlug(pkg.name)}/index.html.md`
   lines.push(
     pkg.description ? `- [${pkg.name}](${url}): ${pkg.description}` : `- [${pkg.name}](${url})`,
   )
 }
-lines.push('')
-lines.push('## Per-package full reference')
-lines.push('')
-lines.push(
-  '> Same content as `llms-full.txt` below, but split per package so each file fits in a smaller context window. Pull only the package(s) you need.',
-)
-lines.push('')
-for (const pkg of packages) {
-  const fullUrl = `${SITE_URL}/${packageSlug(pkg.name)}/llms-full.txt`
-  lines.push(`- [${pkg.name}](${fullUrl})`)
-}
-lines.push('')
-lines.push('## Optional')
-lines.push('')
-lines.push(
-  `- [Full reference](${SITE_URL}/llms-full.txt): every public symbol across all packages, concatenated. ~1.2M tokens — only useful for agents with a 1M+ context window. For everything else, use the per-package files above.`,
-)
 lines.push('')
 
 await fs.writeFile(LLMS_FILE, lines.join('\n'), 'utf-8')
@@ -175,65 +157,3 @@ console.log(`Wrote ${SITEMAP_FILE} with ${urls.length} URLs`)
 const robots = ['User-agent: *', 'Allow: /', '', `Sitemap: ${SITE_URL}/sitemap.xml`, ''].join('\n')
 await fs.writeFile(ROBOTS_FILE, robots, 'utf-8')
 console.log(`Wrote ${ROBOTS_FILE}`)
-
-async function collectIndexMdPaths(dir: string): Promise<string[]> {
-  const entries = await fs.readdir(dir, {withFileTypes: true, recursive: true})
-  return entries
-    .filter((e) => e.isFile() && e.name === 'index.md')
-    .map((e) => path.join(e.parentPath ?? dir, e.name))
-}
-
-function mdPathToUrl(filePath: string): string {
-  const rel = path.relative(DOCS_DIR, filePath)
-  const dir = path.dirname(rel).split(path.sep).join('/')
-  const slug = dir === '.' ? '' : `${dir}/`
-  return `${SITE_URL}/${slug}`
-}
-
-const mdFiles = (await collectIndexMdPaths(DOCS_DIR)).sort()
-
-async function buildSections(files: string[]): Promise<string[]> {
-  const out: string[] = []
-  for (const file of files) {
-    const url = mdPathToUrl(file)
-    const body = (await fs.readFile(file, 'utf-8')).trim()
-    if (!body) continue
-    out.push('---', '', `Source: ${url}`, '', body, '')
-  }
-  return out
-}
-
-const fullLines: string[] = [
-  '# Sanity API Reference (full)',
-  '',
-  `> Concatenation of every page on ${SITE_URL}/, in markdown form. For the package index, see ${SITE_URL}/llms.txt.`,
-  '',
-  ...(await buildSections(mdFiles)),
-]
-await fs.writeFile(LLMS_FULL_FILE, fullLines.join('\n'), 'utf-8')
-console.log(`Wrote ${LLMS_FULL_FILE} with ${mdFiles.length} pages`)
-
-const filesByPackage = new Map<string, string[]>()
-for (const file of mdFiles) {
-  const rel = path.relative(DOCS_DIR, file).split(path.sep).join('/')
-  for (const pkg of packages) {
-    const slug = packageSlug(pkg.name)
-    if (rel === `${slug}/index.md` || rel.startsWith(`${slug}/`)) {
-      if (!filesByPackage.has(slug)) filesByPackage.set(slug, [])
-      filesByPackage.get(slug)!.push(file)
-      break
-    }
-  }
-}
-
-for (const pkg of packages) {
-  const slug = packageSlug(pkg.name)
-  const pkgFiles = filesByPackage.get(slug) ?? []
-  if (pkgFiles.length === 0) continue
-  const pkgLines: string[] = [`# ${pkg.name}`, '']
-  if (pkg.description) pkgLines.push(`> ${pkg.description}`, '')
-  pkgLines.push(...(await buildSections(pkgFiles)))
-  const outPath = path.join(DOCS_DIR, slug, 'llms-full.txt')
-  await fs.writeFile(outPath, pkgLines.join('\n'), 'utf-8')
-  console.log(`Wrote ${outPath} with ${pkgFiles.length} pages`)
-}

--- a/src/build-llms.ts
+++ b/src/build-llms.ts
@@ -5,6 +5,7 @@ const SITE_URL = 'https://reference.sanity.io'
 const INPUT_DIR = 'input-docs'
 const DOCS_DIR = 'docs'
 const LLMS_FILE = 'docs/llms.txt'
+const ROOT_MD_FILE = 'docs/index.html.md'
 const SITEMAP_FILE = 'docs/sitemap.xml'
 const ROBOTS_FILE = 'docs/robots.txt'
 
@@ -123,8 +124,11 @@ for (const pkg of packages) {
 }
 lines.push('')
 
-await fs.writeFile(LLMS_FILE, lines.join('\n'), 'utf-8')
+const llmsBody = lines.join('\n')
+await fs.writeFile(LLMS_FILE, llmsBody, 'utf-8')
 console.log(`Wrote ${LLMS_FILE} with ${packages.length} packages`)
+await fs.writeFile(ROOT_MD_FILE, llmsBody, 'utf-8')
+console.log(`Wrote ${ROOT_MD_FILE} (mirrors llms.txt)`)
 
 async function collectIndexHtmlPaths(dir: string): Promise<string[]> {
   const entries = await fs.readdir(dir, {withFileTypes: true, recursive: true})

--- a/typedoc.json
+++ b/typedoc.json
@@ -14,7 +14,7 @@
       "name": "markdown",
       "path": "./docs",
       "options": {
-        "entryFileName": "index.md",
+        "entryFileName": "index.html.md",
         "cleanOutputDir": false,
         "hideBreadcrumbs": true,
         "hidePageHeader": true

--- a/typedoc.json
+++ b/typedoc.json
@@ -7,6 +7,20 @@
   "sortEntryPoints": false,
   "includeVersion": false,
   "router": "structure-dir",
+  "plugin": ["typedoc-plugin-markdown"],
+  "outputs": [
+    {"name": "html", "path": "./docs"},
+    {
+      "name": "markdown",
+      "path": "./docs",
+      "options": {
+        "entryFileName": "index.md",
+        "cleanOutputDir": false,
+        "hideBreadcrumbs": true,
+        "hidePageHeader": true
+      }
+    }
+  ],
   "readme": "./README.typedoc.md",
   "customCss": "theme/style.css",
   "customFooterHtml": "<a href=\"https://www.sanity.io?ref=reference-docs-site\">Sanity Content Operating System</a><!-- Fathom - beautiful, simple website analytics --> <script src=\"https://cdn.usefathom.com/script.js\" data-site=\"XRTTNUXT\" defer></script> <!-- / Fathom --><!-- Google Tag Manager --><script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0], j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-N3ZSHCP');</script><noscript><iframe src=\"https://www.googletagmanager.com/ns.html?id=GTM-N3ZSHCP\" height=\"0\" width=\"0\" style=\"display:none;visibility:hidden\"></iframe></noscript><!-- End Google Tag Manager -->",


### PR DESCRIPTION
## Summary

Adds [llmstxt.org](https://llmstxt.org/)-aligned support so AI agents can navigate the reference docs without crawling HTML:

- **`/llms.txt`** — discovery hub at site root. H1 + summary + a single `## Packages` section listing each library by name, description, and a direct link to its markdown landing page.
- **Per-page markdown sibling** for every HTML page — `<page>/index.html.md` next to `<page>/index.html`, matching the spec convention "URLs without file names should append `index.html.md`". Available for the package landing, every sub-module, and every leaf symbol — ~2,094 markdown pages mirroring the HTML site 1:1.

Closes [DOC-2118](https://linear.app/sanity/issue/DOC-2118/add-llms-fulltxt-and-per-page-markdown-to-referencesanityio). Follow-up to #23.

## Implementation

Uses [`typedoc-plugin-markdown`](https://typedoc-plugin-markdown.org/) registered in TypeDoc 0.28's [`outputs` array](https://typedoc.org/documents/Options.Output.html#outputs):

```json
"outputs": [
  {"name": "html", "path": "./docs"},
  {
    "name": "markdown",
    "path": "./docs",
    "options": {
      "entryFileName": "index.html.md",
      "cleanOutputDir": false,
      "hideBreadcrumbs": true,
      "hidePageHeader": true
    }
  }
]
```

A single `npx typedoc` invocation runs both renderers from one analysis pass — the HTML pass cleans `./docs` and writes its tree, then the markdown pass writes `index.html.md` files alongside without clobbering. `cleanOutputDir: false` on the second output is the key. Cross-references inside the markdown auto-rewrite to relative `index.html.md` links since the plugin uses `entryFileName` for both.

`build-llms.ts` then writes `llms.txt` with package bullets pointing directly at each landing page's `index.html.md` so agents land on markdown without guessing.

### What we considered and dropped

An earlier iteration of this PR added `llms-full.txt` (site-wide concat) and per-package `<pkg>/llms-full.txt` files. Measurement showed:

- The site-wide file was **~1.19M tokens** — only ingestible by 1M+ context models, and even then ~all of the budget.
- 10 of 11 per-package files fit in 200K, but the `sanity` package alone was 605K.
- All of them were redundant with the per-page markdown — an agent that wants a package's full content can fetch its `index.html.md` (which lists every child) and follow links, paying only for what it actually reads.
- `llms-full.txt` is **not** in the formal llmstxt.org spec; it's a community pattern (FastHTML's `llms-ctx-full.txt`) for inlining the URLs *listed in `llms.txt`*, not a site-wide dump.

So the final shape is the spec minimum: `llms.txt` + per-page `.html.md`. Simple, no oversized files to maintain, and an agent can navigate from package → submodule → symbol with one fetch per hop.

### Why typedoc-plugin-markdown instead of a custom JSON walker

Originally I'd planned a custom walk over the TypeDoc JSON tree. After verifying that:
- TypeDoc 0.28 lets the markdown plugin co-exist with HTML in one invocation (no second `typedoc` run, no doubled build),
- the plugin's URL layout matches our `router: "structure-dir"` exactly,
- output quality is faithful (TSDoc tags, code fences, cross-refs all preserved),

…the custom walker would have been unnecessary work. We get faithful rendering from a maintained plugin and our post-build step shrinks back to a few dozen lines.

## Acceptance criteria

The original DOC-2118 spec asked for `llms-full.txt` and per-page markdown. We're shipping per-page markdown (full coverage) and `llms.txt` (the spec's actual primary file), and **not** shipping `llms-full.txt` after the size measurement showed it isn't usable. Per-page markdown serves the same need at 1/N the cost.

- [x] Per-symbol markdown at predictable URL — `index.html.md` sibling to every `index.html`, all packages, all symbols
- [x] `llms.txt` updated and spec-aligned (H1, summary, `## Packages` with descriptions, package links pointing at markdown)
- [x] Build budget — markdown render is ~5–10s on top of the ~30s HTML baseline, well under doubling

## Test plan

Vercel preview: https://reference-api-typedoc-git-doc-2118.sanity.build (Vercel SSO required to view).

Verified live:

- [x] [`/llms.txt`](https://reference-api-typedoc-git-doc-2118.sanity.build/llms.txt) — 200, `text/plain`, lists all 11 packages with `index.html.md` URLs and descriptions
- [x] Package landing markdown — e.g. [`/_sanity/sdk-react/index.html.md`](https://reference-api-typedoc-git-doc-2118.sanity.build/_sanity/sdk-react/index.html.md) — 200, `text/markdown`, readme + child link tree
- [x] Sub-module index — e.g. [`/_sanity/client/csm/index.html.md`](https://reference-api-typedoc-git-doc-2118.sanity.build/_sanity/client/csm/index.html.md) — 200, `text/markdown`, lists Namespaces / Interfaces / Type Aliases / Functions with relative `.html.md` links
- [x] Per-symbol leaf — e.g. [`/_sanity/client/csm/ApplySourceDocumentsUpdateFunction/index.html.md`](https://reference-api-typedoc-git-doc-2118.sanity.build/_sanity/client/csm/ApplySourceDocumentsUpdateFunction/index.html.md) — 200, `text/markdown`, full TSDoc + signature + GitHub source link
- [x] Site root markdown — [`/index.html.md`](https://reference-api-typedoc-git-doc-2118.sanity.build/index.html.md) — 200
- [x] Old/dropped paths return 404: `/llms-full.txt`, `/_sanity/sdk-react/llms-full.txt`, `/sanity/llms-full.txt`, `/_sanity/sdk-react/index.md`

Regressions absent:

- [x] HTML pages render normally (default theme, navigation, assets intact)
- [x] [`/sitemap.xml`](https://reference-api-typedoc-git-doc-2118.sanity.build/sitemap.xml) — 2,094 URLs, **0 `.md` URLs**
- [x] Vercel build succeeded (deployment status: `SUCCESS`)
