### PR TITLE
chore: add Conductor setup for authenticated browser realms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,10 @@
 node_modules
 docs/
 .env
+.env.local
 input-docs/
 .DS_Store
 dist/
 .vercel
 .idea
+.claude/auth/

--- a/conductor.json
+++ b/conductor.json
@@ -1,0 +1,6 @@
+{
+  "scripts": {
+    "setup": "claude-dev-setup --realms=sanity,github,vercel"
+  },
+  "filesToCopy": [".env"]
+}


### PR DESCRIPTION
## Summary
- Wire `claude-dev-setup` as the Conductor `setup` script. Each new workspace gets pre-fetched authenticated browser state at `.claude/auth/state.json` for the **sanity**, **github**, and **vercel** realms (no GCS — this repo doesn't touch Google Cloud).
- Cookies are sourced from a localhost auth daemon that reads from a long-running master Chrome on `:9222` (no SSO inside agents, no tokens in transcripts).
- Update `.gitignore` to keep the per-workspace `.env.local` and `.claude/auth/` out of commits.

## Why these realms
This repo's build is data-only via `@sanity/client` and doesn't need browser auth at build time. Realms are picked for what an **agent working in the repo** is likely to need: Sanity content surfaces (`*.sanity.io`, `admin.sanity.io`), GitHub PR/workflow review, and Vercel deploy/preview status.

## Test plan
- [ ] Create a Conductor workspace against this branch and confirm `claude-dev-setup` runs cleanly from the `setup` hook.
- [ ] Verify `.claude/auth/state.json` is written with mode 0600 and a non-zero cookie count.
- [ ] Verify `.env.local` contains the `# >>> claude-dev-setup` block with `AUTH_DOCK_URL`, `STORAGE_STATE_PATH`, `CLAUDE_DEV_REALMS=sanity,github,vercel`, and `PORT=$CONDUCTOR_PORT`.
- [ ] Verify the workspace's `CLAUDE.md` has the `<!-- >>> claude-dev-setup -->` fragment appended (idempotent — rerun does not duplicate).
- [ ] Verify `filesToCopy: [".env"]` actually copies the existing `.env` into the workspace so `pnpm build:docs` still works.